### PR TITLE
Add support for DynamoDB query

### DIFF
--- a/backends/client.go
+++ b/backends/client.go
@@ -81,8 +81,14 @@ func New(config Config) (StoreClient, error) {
 		return vault.New(backendNodes[0], config.AuthType, vaultConfig)
 	case "dynamodb":
 		table := config.Table
-		log.Info("DynamoDB table set to " + table)
-		return dynamodb.NewDynamoDBClient(table)
+		query := config.Query
+		if table != "" {
+			log.Info("DynamoDB table set to " + table)
+		}
+		if query != "" {
+			log.Info("DynamoDB query set to " + query)
+		}
+		return dynamodb.NewDynamoDBClient(table, query)
 	case "ssm":
 		return ssm.New()
 	}

--- a/backends/config.go
+++ b/backends/config.go
@@ -5,26 +5,27 @@ import (
 )
 
 type Config struct {
-	AuthToken    string     `toml:"auth_token"`
-	AuthType     string     `toml:"auth_type"`
-	Backend      string     `toml:"backend"`
-	BasicAuth    bool       `toml:"basic_auth"`
-	ClientCaKeys string     `toml:"client_cakeys"`
-	ClientCert   string     `toml:"client_cert"`
-	ClientKey    string     `toml:"client_key"`
-        ClientInsecure bool     `toml:"client_insecure"`
-	BackendNodes util.Nodes `toml:"nodes"`
-	Password     string     `toml:"password"`
-	Scheme       string     `toml:"scheme"`
-	Table        string     `toml:"table"`
-	Separator    string     `toml:"separator"`
-	Username     string     `toml:"username"`
-	AppID        string     `toml:"app_id"`
-	UserID       string     `toml:"user_id"`
-	RoleID       string     `toml:"role_id"`
-	SecretID     string     `toml:"secret_id"`
-	YAMLFile     util.Nodes `toml:"file"`
-	Filter       string     `toml:"filter"`
-	Path         string     `toml:"path"`
-	Role         string
+	AuthToken      string     `toml:"auth_token"`
+	AuthType       string     `toml:"auth_type"`
+	Backend        string     `toml:"backend"`
+	BasicAuth      bool       `toml:"basic_auth"`
+	ClientCaKeys   string     `toml:"client_cakeys"`
+	ClientCert     string     `toml:"client_cert"`
+	ClientKey      string     `toml:"client_key"`
+	ClientInsecure bool       `toml:"client_insecure"`
+	BackendNodes   util.Nodes `toml:"nodes"`
+	Password       string     `toml:"password"`
+	Scheme         string     `toml:"scheme"`
+	Table          string     `toml:"table"`
+	Query          string     `toml:"query"`
+	Separator      string     `toml:"separator"`
+	Username       string     `toml:"username"`
+	AppID          string     `toml:"app_id"`
+	UserID         string     `toml:"user_id"`
+	RoleID         string     `toml:"role_id"`
+	SecretID       string     `toml:"secret_id"`
+	YAMLFile       util.Nodes `toml:"file"`
+	Filter         string     `toml:"filter"`
+	Path           string     `toml:"path"`
+	Role           string
 }

--- a/backends/dynamodb/client.go
+++ b/backends/dynamodb/client.go
@@ -1,7 +1,9 @@
 package dynamodb
 
 import (
+	"encoding/json"
 	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -14,12 +16,13 @@ import (
 type Client struct {
 	client *dynamodb.DynamoDB
 	table  string
+	query  *dynamodb.QueryInput
 }
 
 // NewDynamoDBClient returns an *dynamodb.Client with a connection to the region
 // configured via the AWS_REGION environment variable.
 // It returns an error if the connection cannot be made or the table does not exist.
-func NewDynamoDBClient(table string) (*Client, error) {
+func NewDynamoDBClient(table string, queryStr string) (*Client, error) {
 	var c *aws.Config
 	if os.Getenv("DYNAMODB_LOCAL") != "" {
 		log.Debug("DYNAMODB_LOCAL is set")
@@ -41,16 +44,41 @@ func NewDynamoDBClient(table string) (*Client, error) {
 
 	d := dynamodb.New(session)
 
-	// Check if the table exists
-	_, err = d.DescribeTable(&dynamodb.DescribeTableInput{TableName: &table})
-	if err != nil {
-		return nil, err
+	if table != "" {
+		// Check if the table exists
+		_, err = d.DescribeTable(&dynamodb.DescribeTableInput{TableName: &table})
+		if err != nil {
+			return nil, err
+		}
 	}
-	return &Client{d, table}, nil
+
+	var query *dynamodb.QueryInput
+
+	if queryStr != "" {
+		err = json.Unmarshal([]byte(queryStr), &query)
+		if err != nil {
+			return nil, err
+		}
+		if query.TableName == nil || *query.TableName == "" {
+			query.SetTableName(table)
+		}
+	}
+
+	client := &Client{
+		client: d,
+		table:  table,
+		query:  query,
+	}
+
+	return client, nil
 }
 
 // GetValues retrieves the values for the given keys from DynamoDB
 func (c *Client) GetValues(keys []string) (map[string]string, error) {
+	if c.query != nil {
+		return c.queryValues(keys)
+	}
+
 	vars := make(map[string]string)
 	for _, key := range keys {
 		// Check if we can find the single item
@@ -108,4 +136,34 @@ func (c *Client) GetValues(keys []string) (map[string]string, error) {
 func (c *Client) WatchPrefix(prefix string, keys []string, waitIndex uint64, stopChan chan bool) (uint64, error) {
 	<-stopChan
 	return 0, nil
+}
+
+func (c *Client) queryValues(keys []string) (map[string]string, error) {
+	vars := make(map[string]string)
+
+	q, err := c.client.Query(c.query)
+
+	if err != nil {
+		return vars, err
+	}
+
+	for _, item := range q.Items {
+		if itemKey, ok := item["key"]; ok && itemKey.S != nil {
+			itemKeyStr := *itemKey.S
+
+			for _, key := range keys {
+				if strings.HasPrefix(itemKeyStr, key) {
+					if val, ok := item["value"]; ok {
+						if val.S != nil {
+							vars[itemKeyStr] = *val.S
+						} else {
+							log.Warning("Skipping key '%s'. 'value' is not of type 'string'.", itemKeyStr)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return vars, nil
 }

--- a/config.go
+++ b/config.go
@@ -44,7 +44,7 @@ func init() {
 	flag.StringVar(&config.ClientCaKeys, "client-ca-keys", "", "client ca keys")
 	flag.StringVar(&config.ClientCert, "client-cert", "", "the client cert")
 	flag.StringVar(&config.ClientKey, "client-key", "", "the client key")
-        flag.BoolVar(&config.ClientInsecure, "client-insecure", false, "Allow connections to SSL sites without certs (only used with -backend=etcd)")
+	flag.BoolVar(&config.ClientInsecure, "client-insecure", false, "Allow connections to SSL sites without certs (only used with -backend=etcd)")
 	flag.StringVar(&config.ConfDir, "confdir", "/etc/confd", "confd conf directory")
 	flag.StringVar(&config.ConfigFile, "config-file", "/etc/confd/confd.toml", "the confd config file")
 	flag.Var(&config.YAMLFile, "file", "the YAML file to watch for changes (only used with -backend=file)")
@@ -69,6 +69,7 @@ func init() {
 	flag.StringVar(&config.SecretID, "secret-id", "", "Vault secret-id to use with the AppRole backend (only used with -backend=vault and auth-type=app-role)")
 	flag.StringVar(&config.Path, "path", "", "Vault mount path of the auth method (only used with -backend=vault)")
 	flag.StringVar(&config.Table, "table", "", "the name of the DynamoDB table (only used with -backend=dynamodb)")
+	flag.StringVar(&config.Query, "query", "", "DynamoDB Query JSON (optional, only used with -backend=dynamodb)")
 	flag.StringVar(&config.Separator, "separator", "", "the separator to replace '/' with when looking up keys in the backend, prefixed '/' will also be removed (only used with -backend=redis)")
 	flag.StringVar(&config.Username, "username", "", "the username to authenticate as (only used with vault and etcd backends)")
 	flag.StringVar(&config.Password, "password", "", "the password to authenticate with (only used with vault and etcd backends)")
@@ -175,8 +176,8 @@ func initConfig() error {
 		}
 	}
 
-	if config.Backend == "dynamodb" && config.Table == "" {
-		return errors.New("No DynamoDB table configured")
+	if config.Backend == "dynamodb" && config.Table == "" && config.Query == "" {
+		return errors.New("No DynamoDB table or query configured")
 	}
 	config.ConfigDir = filepath.Join(config.ConfDir, "conf.d")
 	config.TemplateDir = filepath.Join(config.ConfDir, "templates")


### PR DESCRIPTION
DynamoDB queries can now be passed to confd cli. This query may be used if the default Scan method is too slow or does not return all parameters (e.g. if you have more than 10k keys in your DynamoDB table). If specified confd will use the query and then go through all the results and find the ones that begin with `prefix + key`

Example usage:

```sh
confd -onetime -backend dynamodb -prefix "/app/customer1" -confdir "/etc/confd" -query '{
  "TableName": "settings",
  "IndexName": "instance-type-index",
  "KeyConditionExpression": "instance = :i",
  "ExpressionAttributeValues": {
    ":i": {
      "S": "customer1"
    }
  }
}'
```